### PR TITLE
Menu Display fix

### DIFF
--- a/CMSExample/index.php
+++ b/CMSExample/index.php
@@ -19,7 +19,11 @@
                 <td id="page">
                     <h2>
                         <?php if($sel_subject != NULL){
-                        echo $sel_subject['menu_name'];
+                                echo $sel_subject['menu_name'];
+                                if (isset($con_page['menu_name'])){
+                                 echo   " - " . $con_page['menu_name'];
+                                }
+                        
                         }else{
                             echo $con_page['menu_name'];
                         } ?>


### PR DESCRIPTION
Fixed the menu so when you select the 'subject'
it displays
'subject' - 'content page name'
'page content'

as opposed to

'subject'
'page content'
